### PR TITLE
Take the minimum steps to make the taxonomy extension compatible with…

### DIFF
--- a/src/system/modules/taxonomy/config/autoload.ini
+++ b/src/system/modules/taxonomy/config/autoload.ini
@@ -1,0 +1,19 @@
+;;
+; List modules which are required to be loaded beforehand
+;;
+requires[] = "core"
+
+;;
+; Configure what you want the autoload creator to register
+;;
+register_namespaces = true
+register_classes    = true
+register_templates  = true
+
+;;
+; Override the default configuration for certain sub directories
+;;
+[vendor/*]
+register_namespaces = false
+register_classes    = false
+register_templates  = false

--- a/src/system/modules/taxonomy/config/autoload.php
+++ b/src/system/modules/taxonomy/config/autoload.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+
+/**
+ * Register the classes
+ */
+ClassLoader::addClasses(array
+(
+	'TaxonomyTree' => 'system/modules/taxonomy/TaxonomyTree.php',
+));

--- a/src/system/modules/taxonomy/config/config.php
+++ b/src/system/modules/taxonomy/config/config.php
@@ -1,14 +1,14 @@
-<?php if (!defined('TL_ROOT')) die('You can not access this file directly!');
+<?php
 
 /**
  * TYPOlight webCMS
  *
- * The TYPOlight webCMS is an accessible web content management system that 
- * specializes in accessibility and generates W3C-compliant HTML code. It 
- * provides a wide range of functionality to develop professional websites 
- * including a built-in search engine, form generator, file and user manager, 
- * CSS engine, multi-language support and many more. For more information and 
- * additional TYPOlight applications like the TYPOlight MVC Framework please 
+ * The TYPOlight webCMS is an accessible web content management system that
+ * specializes in accessibility and generates W3C-compliant HTML code. It
+ * provides a wide range of functionality to develop professional websites
+ * including a built-in search engine, form generator, file and user manager,
+ * CSS engine, multi-language support and many more. For more information and
+ * additional TYPOlight applications like the TYPOlight MVC Framework please
  * visit the project website http://www.typolight.org.
  *
  * This is the catalog configuration file.
@@ -16,8 +16,8 @@
  * PHP version 5
  * @copyright  2007 Martin Komara, 2008 Thyon Design, 2008 Evan Ruchelman
  * @author     Martin Komara <martin.komara@gmail.com>, John Brand <john.brand@thyon.com>, Evan Ruchelman <tl@ruchelman.com>
- * @package    CatalogModule 
- * @license    GPL 
+ * @package    CatalogModule
+ * @license    GPL
  * @filesource
  */
 
@@ -31,10 +31,8 @@ $GLOBALS['BE_FFL']['taxonomyTree'] = 'TaxonomyTree';
 
 if (TL_MODE == 'BE')
 {
-	$GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/taxonomy/html/taxonomywizard.js'; 
+	$GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/taxonomy/html/taxonomywizard.js';
 }
 
 $GLOBALS['TL_HOOKS']['executePreActions'][] = array('TaxonomyTree', 'executePreActions');
-$GLOBALS['TL_HOOKS']['executePostActions'][] = array('TaxonomyTree', 'executePostActions')
-
-?>
+$GLOBALS['TL_HOOKS']['executePostActions'][] = array('TaxonomyTree', 'executePostActions');

--- a/src/system/modules/taxonomy/html/.htaccess
+++ b/src/system/modules/taxonomy/html/.htaccess
@@ -1,0 +1,7 @@
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Allow from all
+</IfModule>
+<IfModule mod_authz_core.c>
+  Require all granted
+</IfModule>


### PR DESCRIPTION
… Contao 3.
- add autoload
- add missing semicolon in config.php that would break cached, concatenated versions of config.php
- add .htaccess allowing access to the html folder
